### PR TITLE
use slice names in example identifiers

### DIFF
--- a/input/fsh/EX_RadiotherapyVolume.fsh
+++ b/input/fsh/EX_RadiotherapyVolume.fsh
@@ -8,12 +8,10 @@ Usage: #example
 * meta.lastUpdated = "2020-07-03T10:07:41.050+02:00" //Update of the resource on the server. Not necessarily when the clinical contents was modified
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "PTV50" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151823" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume
@@ -28,12 +26,10 @@ Usage: #example
 * meta.lastUpdated = "2020-07-03T10:07:41.050+02:00" //Update of the resource on the server. Not necessarily when the clinical contents was modified
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "PTV64" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151824" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume
@@ -48,12 +44,10 @@ Usage: #example
 * meta.lastUpdated = "2020-07-03T10:07:41.050+02:00" //Update of the resource on the server. Not necessarily when the clinical contents was modified
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Prostate" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151825" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume
@@ -68,12 +62,10 @@ Usage: #example
 * meta.lastUpdated = "2020-07-03T10:07:41.050+02:00" //Update of the resource on the server. Not necessarily when the clinical contents was modified
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Pelv Ns" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151826" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume
@@ -88,12 +80,10 @@ Usage: #example
 * meta.lastUpdated = "2020-07-03T10:07:41.050+02:00" //Update of the resource on the server. Not necessarily when the clinical contents was modified
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Sem Vs" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151827" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume

--- a/input/fsh/Ex-RadiotherapyCoursePrescription-BilateralBreast.fsh
+++ b/input/fsh/Ex-RadiotherapyCoursePrescription-BilateralBreast.fsh
@@ -285,12 +285,10 @@ Usage: #example
 * meta.lastUpdated = "2020-07-03T10:07:41.050+02:00" //Update of the resource on the server. Not necessarily when the clinical contents was modified
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Left Breast" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.101" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume
@@ -308,12 +306,10 @@ Usage: #example
 * meta.lastUpdated = "2020-07-03T10:07:41.050+02:00" //Update of the resource on the server. Not necessarily when the clinical contents was modified
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Left Breast Boost" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.102" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume
@@ -331,12 +327,10 @@ Usage: #example
 * meta.lastUpdated = "2020-07-03T10:07:41.050+02:00" //Update of the resource on the server. Not necessarily when the clinical contents was modified
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Right Breast" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.103" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume

--- a/input/fsh/Ex-XRTS-01-Prostate-1P-1V.fsh
+++ b/input/fsh/Ex-XRTS-01-Prostate-1P-1V.fsh
@@ -191,12 +191,10 @@ Usage: #example
 * meta.lastUpdated = "2021-10-16T10:07:41.050+02:00"
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Prostate" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.01.01.22.1" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume

--- a/input/fsh/Ex-XRTS-02-Prostate-2P-1V.fsh
+++ b/input/fsh/Ex-XRTS-02-Prostate-2P-1V.fsh
@@ -264,12 +264,10 @@ Usage: #example
 * meta.lastUpdated = "2021-10-16T10:07:41.050+02:00"
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Prostate" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.02.01.22.1" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume

--- a/input/fsh/Ex-XRTS-03-Prostate-1P-3V.fsh
+++ b/input/fsh/Ex-XRTS-03-Prostate-1P-3V.fsh
@@ -269,12 +269,10 @@ Usage: #example
 * meta.lastUpdated = "2021-10-16T10:07:41.050+02:00"
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Prostate" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.03.01.22.1" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume
@@ -290,12 +288,10 @@ Usage: #example
 * meta.lastUpdated = "2021-10-16T10:07:41.050+02:00"
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "PelvNs" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.03.02.22.1" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume
@@ -310,12 +306,10 @@ Usage: #example
 * meta.lastUpdated = "2021-10-16T10:07:41.050+02:00"
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "SemVs" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.03.03.22.1" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume

--- a/input/fsh/Ex-XRTS-04-Breast-3P-3V.fsh
+++ b/input/fsh/Ex-XRTS-04-Breast-3P-3V.fsh
@@ -389,12 +389,10 @@ Usage: #example
 * meta.lastUpdated = "2021-10-16T10:07:41.050+02:00"
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Left Breast" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.04.01.22.1" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume
@@ -411,12 +409,10 @@ Usage: #example
 * meta.lastUpdated = "2021-10-16T10:07:41.050+02:00"
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Left Breast Boost" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.04.02.22.1" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume
@@ -433,12 +429,10 @@ Usage: #example
 * meta.lastUpdated = "2021-10-16T10:07:41.050+02:00"
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Right Breast" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.04.03.22.1" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume

--- a/input/fsh/Ex-XRTS-05-BrainMets-1P-1V-2C.fsh
+++ b/input/fsh/Ex-XRTS-05-BrainMets-1P-1V-2C.fsh
@@ -331,12 +331,10 @@ Usage: #example
 * meta.lastUpdated = "2021-10-16T10:07:41.050+02:00"
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Brain Mets" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.05.01.22.1" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume
@@ -352,12 +350,10 @@ Usage: #example
 * meta.lastUpdated = "2021-10-22T10:07:41.050+02:00"
 * meta.profile[+] = Canonical(RadiotherapyVolume)
 * meta.profile[+] = $mCODERadiotherapyVolume
-* identifier[+]
-  * use = #usual
+* identifier[displayName]
   * system = VarianDoseReferenceId
   * value = "Brain Mets" // display id
-* identifier[+]
-  * use = #official
+* identifier[dicomUid]
   * system = DICOMUID
   * value = "urn:oid:1.2.246.352.71.842418.2121.20150602151.05.02.22.1" // DICOM UID
 * morphology = SCT#228793007 "Planning target volume (observable entity)" // type of volume


### PR DESCRIPTION
Fix to avoid bug in latest sushi 2.4.1 that screws up the examples if slice names are not given.