### PR TITLE
revert to USCore 4.0.0 ... sigh

### DIFF
--- a/input/fsh/SD_RadiotherapyCoursePrescription.fsh
+++ b/input/fsh/SD_RadiotherapyCoursePrescription.fsh
@@ -1,5 +1,5 @@
 Profile: RadiotherapyCoursePrescription
-Parent: USCoreServiceRequest
+Parent: ServiceRequest
 Id: codexrt-radiotherapy-course-prescription
 Title: "Radiotherapy Course Cumulative Prescription"
 Description: "A Radiotherapy Course Prescription is a high-level request for a complete Course of Radiotherapy, which may be fulfilled by one or more Phases."

--- a/input/fsh/SD_RadiotherapyPhasePrescription.fsh
+++ b/input/fsh/SD_RadiotherapyPhasePrescription.fsh
@@ -1,6 +1,6 @@
 
 Profile: RadiotherapyPhasePrescription
-Parent: USCoreServiceRequest
+Parent: ServiceRequest
 Id: codexrt-radiotherapy-phase-prescription
 Title: "Radiotherapy Phase Cumulative Prescription"
 Description: "A Radioherapy Phase Prescription is a request for one series of fractionated treatments using Radiotherapy. It can define treatment parameters such as modality or technique,

--- a/input/fsh/SD_RadiotherapyPlanPrescription.fsh
+++ b/input/fsh/SD_RadiotherapyPlanPrescription.fsh
@@ -1,6 +1,6 @@
 
 Profile: RadiotherapyPlanPrescription
-Parent: USCoreServiceRequest
+Parent: ServiceRequest
 Id: codexrt-radiotherapy-plan-prescription
 Title: "Radiotherapy Plan Prescription"
 Description: "A Radioherapy Plan Prescription is a request for Radiotherapy treatment with a single Radiotherapy Treamtent Plan."

--- a/input/fsh/SD_RadiotherapyPlannedCourse.fsh
+++ b/input/fsh/SD_RadiotherapyPlannedCourse.fsh
@@ -1,5 +1,5 @@
 Profile: RadiotherapyPlannedCourse
-Parent: USCoreServiceRequest
+Parent: ServiceRequest
 Id: codexrt-radiotherapy-planned-course
 Title: "Radiotherapy Planned Course"
 Description: "A Radiotherapy Planned Course covers all Radiotherapy Plans to deliver a complete Course."

--- a/input/fsh/SD_RadiotherapyPlannedPhase.fsh
+++ b/input/fsh/SD_RadiotherapyPlannedPhase.fsh
@@ -1,7 +1,7 @@
 
 
 Profile: RadiotherapyPlannedPhase
-Parent: USCoreServiceRequest
+Parent: ServiceRequest
 Id: codexrt-radiotherapy-planned-phase
 Title: "Radiotherapy Planned Phase"
 Description: "A Radiotherapy Planned Phase is the summary over all Radiotherapy Plans to deliver a single Phase of Radiotherapy treatment."

--- a/input/fsh/SD_RadiotherapyTreatmentPlan.fsh
+++ b/input/fsh/SD_RadiotherapyTreatmentPlan.fsh
@@ -1,5 +1,5 @@
 Profile: RadiotherapyTreatmentPlan
-Parent: USCoreServiceRequest
+Parent: ServiceRequest
 Id: codexrt-radiotherapy-treatment-plan
 Title: "Radiotherapy Treatment Plan"
 Description: "A Radiotherapy Treatment Plan resource describes the treatment that is planned to be delivered with a single Radiotherapy Treatment Plan."

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -7,3 +7,6 @@
 # radiotherapy volumes include varian identifiers, and this is OK
 This element does not match any known slice defined in the profile http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-volume
 This element does not match any known slice defined in the profile http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-course-prescription
+
+# The IG is based on USCore 4.0.0 (because of mCODE depdendency), which does not provide ServiceRequest profile
+US FHIR Usage rules require that all profiles on ServiceRequest derive from the core US profile.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -21,7 +21,7 @@ description: CodeX™ Radiation Therapy is an initiative
   electronic health records.
 license: CC0-1.0
 dependencies:
-  hl7.fhir.us.core: 5.0.1
+  hl7.fhir.us.core: 4.0.0
   hl7.fhir.us.mcode: 2.0.0
 # ╭────────────────────────────────────────────menu.xml────────────────────────────────────────────╮
 # │  To use a provided input/includes/menu.xml file, delete the "menu" property below.             │


### PR DESCRIPTION
The terminology errors were due to the mixture of USCore  dependencies.
mCODE depend on 4.0.0
Codex was at 5.0.1
There was a conflict with VSAC references.

We will revisit this later.  mCODE may do a technical correction/update to get to a 5.0.1 base.