### PR TITLE
Diseasestatus

### DIFF
--- a/input/fsh/AL_mCODE.fsh
+++ b/input/fsh/AL_mCODE.fsh
@@ -2,7 +2,10 @@
 Alias: $mCODECancerPatient = http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient
 Alias: $mCODERadiotherapyCourseSummary = http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-course-summary
 Alias: $mCODERadiotherapyVolume = http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-volume
-
+Alias: $mCODECancerDiseaseStatus = http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status
+Alias: $mCODEPrimaryCancerCondition = http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-primary-cancer-condition
+Alias: $mCODESecondaryCancerCondition = http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-secondary-cancer-condition
+Alias: $mCODETumor = http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tumor
 // Extensions
 Alias: $mCODERadiotherapyModalityAndTechnique = http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-modality-and-technique
 Alias: $mCODERadiotherapyDoseDeliveredToVolume = http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-dose-delivered-to-volume
@@ -12,6 +15,7 @@ Alias: $mCODERadiotherapyTechnique = http://hl7.org/fhir/us/mcode/StructureDefin
 // ValueSets
 Alias: $mCODERadiotherapyTreatmentLocationVS = http://hl7.org/fhir/us/mcode/ValueSet/mcode-radiotherapy-treatment-location-vs
 Alias: $mCODECancerDisorderVS = http://hl7.org/fhir/us/mcode/ValueSet/mcode-cancer-disorder-vs
+
 
 // Codesystems
 Alias: $mCODESCT_TBD = http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs

--- a/input/fsh/SD_DiseaseStatus.fsh
+++ b/input/fsh/SD_DiseaseStatus.fsh
@@ -7,7 +7,10 @@ Description: "Disease Status Reported by Radiation Oncologist"
 // can't do this, so we add extension
 //  * focus only Reference($mCODEPrimaryCancerCondition or $mCODESecondaryCancerCondition or $mCODETumor or RadiotherapyVolume)
 * extension contains
-    RadiotherapyVolumeExtension named radiotherapyVolume 0..1
+    RadiotherapyVolumeExtension named radiotherapyVolume 0..*
+* valueCodeableConcept.extension contains
+    ProgressionQualifier named progressionQualifier 0..*
+// may need invariant so that progression qualifier can only be provided if value is progressive disease
 
 Extension: RadiotherapyVolumeExtension
 Id: codexrt-radiotherapy-volume-extension
@@ -16,3 +19,47 @@ Description: "Extension providing a reference to a RadiotherapyVolume"
 * . ^short = "Radiotherapy Volume"
 * value[x] only Reference(RadiotherapyVolume)
 * value[x] 1..1
+
+Extension: ProgressionQualifier
+Id: codexrt-radiotherapy-progression-qualifier
+Title: "Disease Progression Qualifier"
+Description: "Extension providing a qualifier for a disease progression"
+* . ^short = "Progression Qualifier"
+* value[x] only CodeableConcept
+* value[x] from ProgressionQualiierVS (required)
+* value[x] 1..1
+
+ValueSet: ProgressionQualiierVS
+Id: progression-qualifier-vs
+Title: "Progression Qualifier"
+Description: "Qualifiers for Disease Progression"
+* ^experimental = false
+* SCT#80534008 "Biochemical (qualifier value)"
+* SCT#63161005 "Principal (qualifier value)"
+* SCT#255470001 "Local (qualifier value)"
+* SCT#263820005 "Nodal (qualifier value)"
+* SCT#261007001 "Distant (qualifier value)"
+
+
+Instance: cancer-disease-status-22A
+InstanceOf: RadiotherapyDiseaseStatus
+Description: "Extended example: example showing disease status (patient's condition regression)"
+* extension[evidenceType].valueCodeableConcept = SCT#363679005 "Imaging (procedure)"
+* status = #final "final"
+//* code = LNC#97509-4 "Cancer Disease Progression"
+* subject = Reference(Patient-XRTS-01-22A)
+* effectiveDateTime = "2018-11-01"
+* performer = Reference(Practitioner-1005)
+* focus = Reference(Diagnosis-2-Prostate)
+* valueCodeableConcept = SCT#268910001 "Patient's condition improved (finding)"
+* valueCodeableConcept
+  * extension[progressionQualifier][0]
+    * valueCodeableConcept = SCT#263820005 "Nodal (qualifier value)"
+  * extension[progressionQualifier][+]
+    * valueCodeableConcept = SCT#80534008 "Biochemical (qualifier value)"
+* extension[radiotherapyVolume][0]
+  * valueReference  = Reference(RadiotherapyVolume-03-Prostate)
+* extension[radiotherapyVolume][+]
+  * valueReference  = Reference(RadiotherapyVolume-04-PelvNs)
+* extension[radiotherapyVolume][+]
+  * valueReference  = Reference(RadiotherapyVolume-05-SemVs)

--- a/input/fsh/SD_DiseaseStatus.fsh
+++ b/input/fsh/SD_DiseaseStatus.fsh
@@ -11,6 +11,14 @@ Description: "Disease Status Reported by Radiation Oncologist"
 * valueCodeableConcept.extension contains
     ProgressionQualifier named progressionQualifier 0..*
 // may need invariant so that progression qualifier can only be provided if value is progressive disease
+* valueCodeableConcept obeys RestrictQualifier
+
+Invariant: RestrictQualifier
+Description:  "Only allow qualifier for one value status"
+Severity: #error
+Expression: "coding.code != '271299001'
+        implies not extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-progression-qualifier').exists()"
+
 
 Extension: RadiotherapyVolumeExtension
 Id: codexrt-radiotherapy-volume-extension

--- a/input/fsh/SD_DiseaseStatus.fsh
+++ b/input/fsh/SD_DiseaseStatus.fsh
@@ -1,0 +1,18 @@
+Profile: RadiotherapyDiseaseStatus
+Parent: $mCODECancerDiseaseStatus
+Id: codexrt-radiotherapy-disease-status
+Title: "Radiotherapy Disease Status"
+Description: "Disease Status Reported by Radiation Oncologist"
+* ^status = #draft
+// can't do this, so we add extension
+//  * focus only Reference($mCODEPrimaryCancerCondition or $mCODESecondaryCancerCondition or $mCODETumor or RadiotherapyVolume)
+* extension contains
+    RadiotherapyVolumeExtension named radiotherapyVolume 0..1
+
+Extension: RadiotherapyVolumeExtension
+Id: codexrt-radiotherapy-volume-extension
+Title: "Radiotherapy Volume Extension"
+Description: "Extension providing a reference to a RadiotherapyVolume"
+* . ^short = "Radiotherapy Volume"
+* value[x] only Reference(RadiotherapyVolume)
+* value[x] 1..1

--- a/input/fsh/SD_DiseaseStatus.fsh
+++ b/input/fsh/SD_DiseaseStatus.fsh
@@ -51,7 +51,7 @@ Description: "Extended example: example showing disease status (patient's condit
 * effectiveDateTime = "2018-11-01"
 * performer = Reference(Practitioner-1005)
 * focus = Reference(Diagnosis-2-Prostate)
-* valueCodeableConcept = SCT#268910001 "Patient's condition improved (finding)"
+* valueCodeableConcept = SCT#271299001 "Patient's condition worsened (finding)"   // progression
 * valueCodeableConcept
   * extension[progressionQualifier][0]
     * valueCodeableConcept = SCT#263820005 "Nodal (qualifier value)"

--- a/input/fsh/SD_RadiotherapyDiseaseStatus.fsh
+++ b/input/fsh/SD_RadiotherapyDiseaseStatus.fsh
@@ -40,7 +40,7 @@ Description: "Extension providing a qualifier for a disease progression"
 ValueSet: ProgressionQualiierVS
 Id: progression-qualifier-vs
 Title: "Progression Qualifier"
-Description: "Qualifiers for Disease Progression"
+Description: "Qualifiers that describe disease progression and/or disease recurrence"
 * ^experimental = false
 * SCT#80534008 "Biochemical (qualifier value)"
 * SCT#63161005 "Principal (qualifier value)"

--- a/input/fsh/SD_RadiotherapyDiseaseStatus.fsh
+++ b/input/fsh/SD_RadiotherapyDiseaseStatus.fsh
@@ -9,15 +9,15 @@ Description: "Disease Status Reported by Radiation Oncologist"
 * extension contains
     RadiotherapyVolumeExtension named radiotherapyVolume 0..*
 * valueCodeableConcept.extension contains
-    ProgressionQualifier named progressionQualifier 0..*
+    DiseaseProgressionQualifier named diseaseProgressionQualifier 0..*
 // may need invariant so that progression qualifier can only be provided if value is progressive disease
-* valueCodeableConcept obeys RestrictQualifier
+* valueCodeableConcept obeys RestrictDiseaseProgressionQualifier
 
-Invariant: RestrictQualifier
+Invariant: RestrictDiseaseProgressionQualifier
 Description:  "Only allow qualifier for one value status"
 Severity: #error
 Expression: "coding.code != '271299001'
-        implies not extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-progression-qualifier').exists()"
+        implies not extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-disease-progression-qualifier').exists()"
 
 
 Extension: RadiotherapyVolumeExtension
@@ -28,18 +28,18 @@ Description: "Extension providing a reference to a RadiotherapyVolume"
 * value[x] only Reference(RadiotherapyVolume)
 * value[x] 1..1
 
-Extension: ProgressionQualifier
+Extension: DiseaseProgressionQualifier
 Id: codexrt-radiotherapy-progression-qualifier
 Title: "Disease Progression Qualifier"
 Description: "Extension providing a qualifier for a disease progression"
 * . ^short = "Progression Qualifier"
 * value[x] only CodeableConcept
-* value[x] from ProgressionQualiierVS (required)
+* value[x] from DiseaseProgressionQualiierVS (required)
 * value[x] 1..1
 
-ValueSet: ProgressionQualiierVS
-Id: progression-qualifier-vs
-Title: "Progression Qualifier"
+ValueSet: DiseaseProgressionQualiierVS
+Id: codexrt-disease-progression-qualifier-vs
+Title: "Disease Progression Qualifier"
 Description: "Qualifiers that describe disease progression and/or disease recurrence"
 * ^experimental = false
 * SCT#80534008 "Biochemical (qualifier value)"
@@ -61,9 +61,9 @@ Description: "Extended example: example showing disease status (patient's condit
 * focus = Reference(Diagnosis-2-Prostate)
 * valueCodeableConcept = SCT#271299001 "Patient's condition worsened (finding)"   // progression
 * valueCodeableConcept
-  * extension[progressionQualifier][0]
+  * extension[diseaseProgressionQualifier][0]
     * valueCodeableConcept = SCT#263820005 "Nodal (qualifier value)"
-  * extension[progressionQualifier][+]
+  * extension[diseaseProgressionQualifier][+]
     * valueCodeableConcept = SCT#80534008 "Biochemical (qualifier value)"
 * extension[radiotherapyVolume][0]
   * valueReference  = Reference(RadiotherapyVolume-03-Prostate)


### PR DESCRIPTION
SHould be reviewed by Martin and Sharon.

1) Added a new DiseaseStatus profile based on mCODE
2) Adds an extension to reference a Treatment Volume (mCODE STU3 will facilitate this, so extension will be shortlived)
3) Adds a qualifier on the statustrend for type of progression (local, nodal, etc).