### PR TITLE
add unit to energy

### DIFF
--- a/input/fsh/EX_RadiotherapyPhasePrescription.fsh
+++ b/input/fsh/EX_RadiotherapyPhasePrescription.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
   * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MV "megavolt"
 * extension[radiotherapyFractionsPrescribed].valuePositiveInt = 25
 // Prescription Target Site "Prostate"
 * extension[radiotherapyDosePrescribedToVolume][+]
@@ -67,7 +67,7 @@ Usage: #example
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
   * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MV "megavolt"
 * extension[radiotherapyFractionsPrescribed].valuePositiveInt = 19
 // Prescription Target Site "Prostate"
 * extension[radiotherapyDosePrescribedToVolume][+]

--- a/input/fsh/EX_RadiotherapyPhasePrescription.fsh
+++ b/input/fsh/EX_RadiotherapyPhasePrescription.fsh
@@ -10,7 +10,8 @@ Usage: #example
   * extension[modality].valueCodeableConcept = SCT#1156506007 "External beam radiation therapy using photons (procedure)"
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18 //unit is fixed in profile
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
 * extension[radiotherapyFractionsPrescribed].valuePositiveInt = 25
 // Prescription Target Site "Prostate"
 * extension[radiotherapyDosePrescribedToVolume][+]
@@ -65,7 +66,8 @@ Usage: #example
   * extension[modality].valueCodeableConcept = SCT#1156506007 "External beam radiation therapy using photons (procedure)"
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18 //unit is fixed in profile
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
 * extension[radiotherapyFractionsPrescribed].valuePositiveInt = 19
 // Prescription Target Site "Prostate"
 * extension[radiotherapyDosePrescribedToVolume][+]

--- a/input/fsh/EX_RadiotherapyPlanPrescription.fsh
+++ b/input/fsh/EX_RadiotherapyPlanPrescription.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
   * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MV "megavolt"
 * extension[radiotherapyFractionsPrescribed].valuePositiveInt = 25
 // Prescription Target Site "Prostate"
 * extension[radiotherapyDosePrescribedToVolume][+]
@@ -67,7 +67,7 @@ Usage: #example
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
   * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MV "megavolt"
 * extension[radiotherapyFractionsPrescribed].valuePositiveInt = 19
 // Prescription Target Site "Prostate"
 * extension[radiotherapyDosePrescribedToVolume][+]

--- a/input/fsh/EX_RadiotherapyPlanPrescription.fsh
+++ b/input/fsh/EX_RadiotherapyPlanPrescription.fsh
@@ -10,7 +10,8 @@ Usage: #example
   * extension[modality].valueCodeableConcept = SCT#1156506007 "External beam radiation therapy using photons (procedure)"
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18 //unit is fixed in profile
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
 * extension[radiotherapyFractionsPrescribed].valuePositiveInt = 25
 // Prescription Target Site "Prostate"
 * extension[radiotherapyDosePrescribedToVolume][+]
@@ -65,7 +66,8 @@ Usage: #example
   * extension[modality].valueCodeableConcept = SCT#1156506007 "External beam radiation therapy using photons (procedure)"
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18 //unit is fixed in profile
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
 * extension[radiotherapyFractionsPrescribed].valuePositiveInt = 19
 // Prescription Target Site "Prostate"
 * extension[radiotherapyDosePrescribedToVolume][+]

--- a/input/fsh/EX_RadiotherapyPlannedPhase.fsh
+++ b/input/fsh/EX_RadiotherapyPlannedPhase.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
   * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MV "megavolt"
 * extension[radiotherapyFractionsPlanned].valuePositiveInt = 25
 // Target Site "Prostate"
 * extension[radiotherapyDosePlannedToVolume][+]
@@ -67,7 +67,7 @@ Usage: #example
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
   * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MV "megavolt"
 * extension[radiotherapyFractionsPlanned].valuePositiveInt = 19
 // Target Site "Prostate"
 * extension[radiotherapyDosePlannedToVolume][+]

--- a/input/fsh/EX_RadiotherapyPlannedPhase.fsh
+++ b/input/fsh/EX_RadiotherapyPlannedPhase.fsh
@@ -10,7 +10,8 @@ Usage: #example
   * extension[modality].valueCodeableConcept = SCT#1156506007 "External beam radiation therapy using photons (procedure)"
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18 //unit is fixed in profile
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
 * extension[radiotherapyFractionsPlanned].valuePositiveInt = 25
 // Target Site "Prostate"
 * extension[radiotherapyDosePlannedToVolume][+]
@@ -65,7 +66,8 @@ Usage: #example
   * extension[modality].valueCodeableConcept = SCT#1156506007 "External beam radiation therapy using photons (procedure)"
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18 //unit is fixed in profile
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
 * extension[radiotherapyFractionsPlanned].valuePositiveInt = 19
 // Target Site "Prostate"
 * extension[radiotherapyDosePlannedToVolume][+]

--- a/input/fsh/EX_RadiotherapyTreatmentPlan.fsh
+++ b/input/fsh/EX_RadiotherapyTreatmentPlan.fsh
@@ -10,7 +10,8 @@ Usage: #example
   * extension[modality].valueCodeableConcept = SCT#1156506007 "External beam radiation therapy using photons (procedure)"
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18 //unit is fixed in profile
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
 * extension[radiotherapyFractionsPlanned].valuePositiveInt = 25
 // Target Site "Prostate"
 * extension[radiotherapyDosePlannedToVolume][+]
@@ -68,7 +69,8 @@ Usage: #example
   * extension[modality].valueCodeableConcept = SCT#1156506007 "External beam radiation therapy using photons (procedure)"
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18 //unit is fixed in profile
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
 * extension[radiotherapyFractionsPlanned].valuePositiveInt = 19
 // Target Site "Prostate"
 * extension[radiotherapyDosePlannedToVolume][+]

--- a/input/fsh/EX_RadiotherapyTreatmentPlan.fsh
+++ b/input/fsh/EX_RadiotherapyTreatmentPlan.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
   * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MV "megavolt"
 * extension[radiotherapyFractionsPlanned].valuePositiveInt = 25
 // Target Site "Prostate"
 * extension[radiotherapyDosePlannedToVolume][+]
@@ -70,7 +70,7 @@ Usage: #example
   * extension[technique][0].valueCodeableConcept = $mCODESCT_TBD#1162782007 "Three dimensional external beam radiation therapy (procedure)"
   //* extension[technique][=].valueCodeableConcept[=].coding[+] = http://varian.com/fhir/CodeSystem/aria-radiotherapyPrescriptionTechnique#ARC "Arc" //violates mCODE invariant
   * extension[radiotherapyEnergyOrIsotope].valueQuantity.value = 18
-  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MeV "megaelectronvolt"
+  * extension[radiotherapyEnergyOrIsotope].valueQuantity = UCUM#MV "megavolt"
 * extension[radiotherapyFractionsPlanned].valuePositiveInt = 19
 // Target Site "Prostate"
 * extension[radiotherapyDosePlannedToVolume][+]

--- a/input/fsh/SD_Extensions.fsh
+++ b/input/fsh/SD_Extensions.fsh
@@ -105,6 +105,9 @@ by the maximum energy, the maximum accelaration voltage, or the used isotope."
 * valueQuantity ^short = "The spectrum of radiation energy characterized by a maximum value.
 For electrons, the maximum energy is given in MeV. For photons, the maximum acceleration voltage is given in MV or kV, although those are not units of energy."
 * valueQuantity from RadiotherapyEnergyUnits (required)
+* valueQuantity.value 1..1
+* valueQuantity.system 1..1
+* valueQuantity.code 1..1
 * valueCodeableConcept ^short = "The isotope used for radiotherapy."
 * valueCodeableConcept from RadiotherapyIsotopes (extensible)
 * value[x] 1..1

--- a/input/fsh/SD_Extensions.fsh
+++ b/input/fsh/SD_Extensions.fsh
@@ -119,7 +119,7 @@ For electrons, the maximum energy is given in MeV. For photons, the maximum acce
 Extension: DicomReference
 Id: codexrt-dicom-reference
 Title: "Reference to DICOM SOP Instance"
-Description: "A Reference to a DICOM SOP Instance."
+Description: "A reference to a DICOM SOP Instance."
 * . ^short = "Reference to DICOM SOP Instance"
 * extension contains
     instanceUid 1..1 MS and

--- a/input/fsh/SD_RadiotherapyPlanPrescription.fsh
+++ b/input/fsh/SD_RadiotherapyPlanPrescription.fsh
@@ -3,7 +3,7 @@ Profile: RadiotherapyPlanPrescription
 Parent: ServiceRequest
 Id: codexrt-radiotherapy-plan-prescription
 Title: "Radiotherapy Plan Prescription"
-Description: "A Radioherapy Plan Prescription is a request for Radiotherapy treatment with a single Radiotherapy Treamtent Plan."
+Description: "A Radiotherapy Plan Prescription is a request for Radiotherapy treatment with a single Radiotherapy Treamtent Plan."
 * insert RadiotherapyPhaseAndPlanPrescriptionCommon
 * code = SnomedRequestedCS#USCRS-33951 "Radiotherapy Treatment Plan (therapy/regime)"
 * insert BasedOnSlicing

--- a/input/fsh/SD_RadiotherapyPlanPrescription.fsh
+++ b/input/fsh/SD_RadiotherapyPlanPrescription.fsh
@@ -3,7 +3,7 @@ Profile: RadiotherapyPlanPrescription
 Parent: ServiceRequest
 Id: codexrt-radiotherapy-plan-prescription
 Title: "Radiotherapy Plan Prescription"
-Description: "A Radiotherapy Plan Prescription is a request for Radiotherapy treatment with a single Radiotherapy Treamtent Plan."
+Description: "A Radiotherapy Plan Prescription is a request for Radiotherapy treatment with a single Radiotherapy Treamtment Plan."
 * insert RadiotherapyPhaseAndPlanPrescriptionCommon
 * code = SnomedRequestedCS#USCRS-33951 "Radiotherapy Treatment Plan (therapy/regime)"
 * insert BasedOnSlicing

--- a/input/fsh/SD_RadiotherapyTreatedPhase.fsh
+++ b/input/fsh/SD_RadiotherapyTreatedPhase.fsh
@@ -2,7 +2,7 @@ Profile:  RadiotherapyTreatedPhase
 Parent:   USCoreProcedure
 Id:       codexrt-radiotherapy-treated-phase
 Title: "Radiotherapy Treated Phase"
-Description: "A summary of a phase of radiotherapy treatment that has been delivered. The scope is a treatment consisting of one or multiple identical fractions.  A phase consists of a set of identical fractions. In this context, identical means that each fraction uses the same modality, technique, dose per fraction, and is applied to the same treatment volume or volumes. Because of their spatial relationship or the technique used,  all treatment volumes do not necessarily receive the same total dose during a phase."
+Description: "A summary of a phase of radiotherapy treatment that has been delivered. A phase consists of a set of identical fractions. In this context, identical means that each fraction uses the same modality, technique, dose per fraction, and is applied to the same treatment volume or volumes. Because of their spatial relationship or the technique used, all treatment volumes do not necessarily receive the same total dose during a phase."
 * insert RadiotherapyTreatedPhaseAndPlanCommon
 * ^status = #draft
 * code = SnomedRequestedCS#USCRS-33527 "Radiotherapy Treatment Phase (therapy/regime)"


### PR DESCRIPTION
Changed energy-or-isotope extension to force having a value and a unit.
Added unit to the examples.
Thanks to Tucker Meyers for the finding that our examples had no unit for the energy (and validation did not detect it).
