### PR TITLE
worked on intros to resource profiles

### DIFF
--- a/input/pagecontent/StructureDefinition-codexrt-radiotherapy-course-prescription-intro.md
+++ b/input/pagecontent/StructureDefinition-codexrt-radiotherapy-course-prescription-intro.md
@@ -1,5 +1,5 @@
 ### Usage
-This profile is used to represent an original order for a complete course of radiotherapy that will be elaborated in orders for phases and plans of treatment. The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
+This profile is used to represent a prescription for a complete course of radiotherapy. An overview of radiotherapy courses, phases, and treatment plans is shown [here](overview.html#codex-rt-resource-profiles). In FHIR, the prescription for a course of radiotherapy is represented as an original order, whereas the elaborated phases and treatment plans are represented as filler orders. The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
 
 ### Conformance
 ServiceRequest resource instances whose code is SNOMEDCT `1217123003` (Radiotherapy course of treatment (regime/therapy)) and whose intent is http://hl7.org/fhir/request-intent#original-order "Original Order" MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly.

--- a/input/pagecontent/StructureDefinition-codexrt-radiotherapy-course-summary-intro.md
+++ b/input/pagecontent/StructureDefinition-codexrt-radiotherapy-course-summary-intro.md
@@ -1,9 +1,9 @@
 ### Usage
 
-This profile is used to capture a course of radiotherapy delivered to a patient. A course of therapy systematically addresses a condition or set of related conditions. The course can include multiple sessions, can be divided into multiple phases, and can last for several months. A course of treatment has a distinct beginning and end. While the Radiotherapy Course Summary can be incrementally updated as the treatment progresses, the primary purpose is to summarize the entire course of treatment from beginning to end. The status element indicates whether the treatment is in progress or complete. The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
+This profile is used to capture a course of radiotherapy delivered to a patient. An overview of radiotherapy courses, phases, and treatment plans is shown [here](overview.html#codex-rt-resource-profiles). A course of therapy systematically addresses a condition or set of related conditions. The course can include multiple sessions, can be divided into multiple phases, and can last for several months. A course of treatment has a distinct beginning and end. While the Radiotherapy Course Summary can be incrementally updated as the treatment progresses, the primary purpose is to summarize the entire course of treatment from beginning to end. The status element indicates whether the treatment is in progress or complete. The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
 
 ### Conformance
 
-Procedure resources whose code is SNOMEDCT  `1217123003` (Radiotherapy course of treatment (regime/therapy)) MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate `meta.profile` accordingly.
+Procedure resources whose code is SNOMEDCT `1217123003` (Radiotherapy course of treatment (regime/therapy)) MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate `meta.profile` accordingly.
 
 {% include markdown-link-references.md %}

--- a/input/pagecontent/StructureDefinition-codexrt-radiotherapy-phase-prescription-intro.md
+++ b/input/pagecontent/StructureDefinition-codexrt-radiotherapy-phase-prescription-intro.md
@@ -1,7 +1,7 @@
 ### Usage
-This profile is used to represent an original order for a single treatment plan of radiotherapy. The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
+This profile is used to represent a prescription for a phase of radiotherapy treatment. An overview of radiotherapy courses, phases, and treatment plans is shown [here](overview.html#codex-rt-resource-profiles). In FHIR, the prescription for a phase of treatment is represented as an original order, whereas the elaborated phase and treatment plans are represented as filler orders. The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
 
 ### Conformance
-ServiceRequest resource instances whose code is SNOMEDCT `1222565005` (Radiotherapy treatment phase (regime/therapy) and whose intent is http://hl7.org/fhir/request-intent#original-order "Original Order" MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly.
+ServiceRequest resource instances whose code is SNOMEDCT `1222565005` (Radiotherapy treatment phase (regime/therapy)) and whose intent is http://hl7.org/fhir/request-intent#original-order "Original Order" MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly.
 
 {% include markdown-link-references.md %}

--- a/input/pagecontent/StructureDefinition-codexrt-radiotherapy-plan-prescription-intro.md
+++ b/input/pagecontent/StructureDefinition-codexrt-radiotherapy-plan-prescription-intro.md
@@ -1,5 +1,5 @@
 ### Usage
-This profile is used to represent an original order for a single treatment plan of radiotherapy. The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
+This profile is used to represent a prescription for a single treatment plan of radiotherapy. An overview of radiotherapy courses, phases, and treatment plans is shown [here](overview.html#codex-rt-resource-profiles). In FHIR, the prescription for a treatment plan is represented as an original order, whereas the elaborated treatment plan is represented as filler order. The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
 
 ### Conformance
 ServiceRequest resource instances whose code is SNOMEDCT `1255724003` (Radiotherapy treatment plan (regime/therapy)) and whose intent is http://hl7.org/fhir/request-intent#original-order "Original Order" MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly.

--- a/input/pagecontent/StructureDefinition-codexrt-radiotherapy-planned-course-intro.md
+++ b/input/pagecontent/StructureDefinition-codexrt-radiotherapy-planned-course-intro.md
@@ -1,6 +1,8 @@
 ### Usage
-This profile is used to represent a filler order for a complete course of radiotherapy that will be elaborated in orders for phases and plans of treatment.
-are filler orders that represent how the radiotherapy system fulfills the prescribed radiotherapy treatment.  The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
+This profile is used to represent a planned course of radiotherapy as elaborated in a radiotherapy treatment planning system.
+An overview of radiotherapy courses, phases, and treatment plans is shown [here](overview.html#codex-rt-resource-profiles).
+In FHIR, treatment plans and the summaries of treatment plans for a phase or a course are represented as filler orders, and the corresponding prescriptions are represented as original orders.
+The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
 
 ### Conformance
 ServiceRequest resource instances whose code is SNOMEDCT `1217123003` (Radiotherapy course of treatment (regime/therapy)) and whose intent is http://hl7.org/fhir/request-intent#filler-order "Filler Order" MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly.

--- a/input/pagecontent/StructureDefinition-codexrt-radiotherapy-planned-phase-intro.md
+++ b/input/pagecontent/StructureDefinition-codexrt-radiotherapy-planned-phase-intro.md
@@ -1,7 +1,10 @@
 ### Usage
-This profile is used to represent an filler order for a single treatment phase of radiotherapy. The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
+This profile is used to represent a planned phase of radiotherapy as elaborated in a radiotherapy treatment planning system.
+An overview of radiotherapy courses, phases, and treatment plans is shown [here](overview.html#codex-rt-resource-profiles).
+In FHIR, treatment plans and the summaries of treatment plans for a phase or a course are represented as filler orders, and the corresponding prescriptions are represented as original orders.
+The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
 
 ### Conformance
-ServiceRequest resource instances whose code is SNOMEDCT `1222565005` (Radiotherapy treatment phase (regime/therapy) and whose intent is http://hl7.org/fhir/request-intent#filler-order "Filler Order" MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly.
+ServiceRequest resource instances whose code is SNOMEDCT `1222565005` (Radiotherapy treatment phase (regime/therapy)) and whose intent is http://hl7.org/fhir/request-intent#filler-order "Filler Order" MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly.
 
 {% include markdown-link-references.md %}

--- a/input/pagecontent/StructureDefinition-codexrt-radiotherapy-treated-phase-intro.md
+++ b/input/pagecontent/StructureDefinition-codexrt-radiotherapy-treated-phase-intro.md
@@ -1,7 +1,7 @@
-This profile is used to capture a phase of radiotherapy delivered to a patient.  The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
+This profile is used to capture a phase of radiotherapy delivered to a patient. An overview of radiotherapy courses, phases, and treatment plans is shown [here](overview.html#codex-rt-resource-profiles). The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
 
 ### Conformance
 
-Procedure resources whose code is SNOMEDCT  `1222565005` (Radiotherapy treatment phase (regime/therapy) MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate `meta.profile` accordingly.
+Procedure resources whose code is SNOMEDCT `1222565005` (Radiotherapy treatment phase (regime/therapy)) MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate `meta.profile` accordingly.
 
 {% include markdown-link-references.md %}

--- a/input/pagecontent/StructureDefinition-codexrt-radiotherapy-treated-plan-intro.md
+++ b/input/pagecontent/StructureDefinition-codexrt-radiotherapy-treated-plan-intro.md
@@ -1,7 +1,7 @@
-This profile is used to capture a treatment plan of radiotherapy delivered to a patient.  The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
+This profile is used to capture a radiotherapy treatment plan delivered to a patient. An overview of radiotherapy courses, phases, and treatment plans is shown [here](overview.html#codex-rt-resource-profiles). The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
 
 ### Conformance
 
-Procedure resources whose code is SNOMEDCT  `1255724003` (Radiotherapy treatment plant (regime/therapy)) MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate `meta.profile` accordingly.
+Procedure resources whose code is SNOMEDCT `1255724003` (Radiotherapy treatment plan (regime/therapy)) MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate `meta.profile` accordingly.
 
 {% include markdown-link-references.md %}

--- a/input/pagecontent/StructureDefinition-codexrt-radiotherapy-treatment-plan-intro.md
+++ b/input/pagecontent/StructureDefinition-codexrt-radiotherapy-treatment-plan-intro.md
@@ -1,5 +1,8 @@
 ### Usage
-This profile is used to represent an filler order for a single treatment plan of radiotherapy. The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
+This profile is used to represent a single radiotherapy treatment plan as elaborated in a radiotherapy treatment planning system.
+An overview of radiotherapy courses, phases, and treatment plans is shown [here](overview.html#codex-rt-resource-profiles).
+In FHIR, treatment plans are represented as filler orders, and the corresponding prescriptions as original orders.
+The relationships between the various radiotherapy profiles are shown [here](overview.html#relationships-between-profiles).
 
 ### Conformance
 ServiceRequest resource instances whose code is SNOMEDCT `1255724003` (Radiotherapy treatment plan (regime/therapy)) and whose intent is http://hl7.org/fhir/request-intent#filler-order "Filler Order" MUST conform to this profile. Any resource intended to conform to this profile SHOULD populate meta.profile accordingly.


### PR DESCRIPTION
Referring to http://build.fhir.org/ig/HL7/codex-radiation-therapy/branches/intros/overview.html#codex-rt-resource-profiles for course vs. phase vs. plan. And flipping intros to first mention what is modelled and then whether it is in FHIR an original order or filler order.