### PR TITLE
fix invariants   valueCodeableConcept --> value

### DIFF
--- a/input/fsh/DEF_Rulesets.fsh
+++ b/input/fsh/DEF_Rulesets.fsh
@@ -82,13 +82,13 @@ Description: "If the respiratory motion management is 'none', then no other resp
 They would also be 'none' or contradict the 'none'.  
 SNOMEDCT code 721031000124102 is \"Radiotherapy without respiratory motion management (regime/therapy)\""
 Severity: #error
-Expression: "extension.exists(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-respiratory-motion-management' and valueCodeableConcept.exists(coding.exists(code = '721031000124102' and system = 'http://hl7.org/fhir/us/codex-radiation-therapy/CodeSystem/snomed-requested-cs'))) implies extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-respiratory-motion-management').count() = 1"
+Expression: "extension.exists(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-respiratory-motion-management' and value.exists(coding.exists(code = '721031000124102' and system = 'http://hl7.org/fhir/us/codex-radiation-therapy/CodeSystem/snomed-requested-cs'))) implies extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-respiratory-motion-management').count() = 1"
 
 Invariant:  codexrt-free-breathing-technique
 Description: "The extension for the technique of free-breathing motion management is only allowed if motion management is free-breathing.
 SNOMEDCT code 721071000124104 is \"Radiotherapy with free breathing (regime/therapy)\""
 Severity: #error
-Expression: "extension.exists(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-free-breathing-motion-mgmt-technique') implies extension.exists(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-respiratory-motion-management' and valueCodeableConcept.exists(coding.exists(code = '721071000124104' and system = 'http://hl7.org/fhir/us/codex-radiation-therapy/CodeSystem/snomed-requested-cs')))"
+Expression: "extension.exists(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-free-breathing-motion-mgmt-technique') implies extension.exists(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-respiratory-motion-management' and value.exists(coding.exists(code = '721071000124104' and system = 'http://hl7.org/fhir/us/codex-radiation-therapy/CodeSystem/snomed-requested-cs')))"
 
 
 RuleSet: RadiotherapyRequestCommon


### PR DESCRIPTION
The IG Publisher started generating errors on the free breathing invariants use of valueCodeableConcept instead of simply value.