### PR TITLE
category of CourseSummary no more from mCODE

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -1,4 +1,4 @@
 [IG]
 ig = fsh-generated/resources/ImplementationGuide-hl7.fhir.us.codex-radiation-therapy.json
-template = hl7.fhir.template#0.5.0
+template = hl7.fhir.template#current
 #template = hl7.fhir.template

--- a/ig.ini
+++ b/ig.ini
@@ -1,4 +1,4 @@
 [IG]
 ig = fsh-generated/resources/ImplementationGuide-hl7.fhir.us.codex-radiation-therapy.json
-# template = hl7.fhir.template#current
-template = hl7.fhir.template
+template = hl7.fhir.template#0.5.0
+#template = hl7.fhir.template

--- a/input/fsh/DEF_Rulesets.fsh
+++ b/input/fsh/DEF_Rulesets.fsh
@@ -79,7 +79,7 @@ RuleSet: MotionManagement
 
 Invariant:  codexrt-motion-management-none
 Description: "If the respiratory motion management is 'none', then no other respiratory motion management extensions are allowed.
-They would also be 'none' or contradict the 'none'.  
+They would also be 'none' or contradict the 'none'.
 SNOMEDCT code 721031000124102 is \"Radiotherapy without respiratory motion management (regime/therapy)\""
 Severity: #error
 Expression: "extension.exists(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-respiratory-motion-management' and value.exists(coding.exists(code = '721031000124102' and system = 'http://hl7.org/fhir/us/codex-radiation-therapy/CodeSystem/snomed-requested-cs'))) implies extension.where(url = 'http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-respiratory-motion-management').count() = 1"
@@ -133,6 +133,7 @@ RuleSet: RadiotherapyProcedureCommon
 * extension[doseDeliveredToVolume].extension contains
     PointDose named pointDose 0..1 MS and
     PrimaryPlanDose named primaryPlanDose 0..1 MS
+* category = SCT#108290001 "Radiation oncology AND/OR radiotherapy"
 * performed[x] only Period
 * performedPeriod.start MS
 * performedPeriod.start ^short = "The date and time when the first therapeutic radiation was delivered."
@@ -200,7 +201,6 @@ RuleSet: RadiotherapyTreatedPhaseAndPlanCommon
 * insert RadiotherapyProcedureCommon
 * extension[doseDeliveredToVolume].extension[fractionsDelivered] 0..0
 * extension[doseDeliveredToVolume].extension[fractionsDelivered] ^short = "Not used in this profile."
-* category = SCT#108290001 // "Radiation oncology AND/OR radiotherapy (procedure)"
 * subject only Reference($mCODECancerPatient)   // must reference mCODE Cancer Patient
 * reasonCode MS
 * reasonCode from $mCODECancerDisorderVS (extensible)

--- a/input/pagecontent/change_log.md
+++ b/input/pagecontent/change_log.md
@@ -1,10 +1,10 @@
 ### CodeX Radiation Therapy STU 1.1 Work in Progress
-These are the changes that were made between STU 1 and STU 1.1 ballot.
+These are the unballoted changes that were made after STU 1 publication.
 
 #### Profile Changes
 * Added required code for Procedure.category in [RadiotherapyCourseSummary](StructureDefinition-codexrt-radiotherapy-course-summary.html). The category was inherited from mCODE [RadiotherapyCourseSummary](https://hl7.org/fhir/us/mcode/STU2.1/StructureDefinition-mcode-radiotherapy-course-summary.html) up to mCODE 2.1.0, but removed in mCODE 3.0.0. Now CodeX RT defines the category for Radiotherapy Course Summary instead of inheriting from mCODE ([FHIR-41764](https://jira.hl7.org/browse/FHIR-41764)).
 
-### CodeX Radiation Therapy  Publication Version
+### CodeX Radiation Therapy STU1 Publication Version
 These are the changes that were made during ballot reconciliation.
 
 #### Narrative Changes

--- a/input/pagecontent/change_log.md
+++ b/input/pagecontent/change_log.md
@@ -1,4 +1,10 @@
-### CodeX Radiation Therapy STU 1 Publication Version
+### CodeX Radiation Therapy STU 1.1 Work in Progress
+These are the changes that were made between STU 1 and STU 1.1 ballot.
+
+#### Profile Changes
+* Added required code for Procedure.category in [RadiotherapyCourseSummary](StructureDefinition-codexrt-radiotherapy-course-summary.html). The category was inherited from mCODE [RadiotherapyCourseSummary](https://hl7.org/fhir/us/mcode/STU2.1/StructureDefinition-mcode-radiotherapy-course-summary.html) up to mCODE 2.1.0, but removed in mCODE 3.0.0. Now CodeX RT defines the category for Radiotherapy Course Summary instead of inheriting from mCODE ([FHIR-41764](https://jira.hl7.org/browse/FHIR-41764)).
+
+### CodeX Radiation Therapy  Publication Version
 These are the changes that were made during ballot reconciliation.
 
 #### Narrative Changes

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,3 +1,8 @@
+ {:.stu-note}
+<div class="stu-note" markdown="1">
+This version STU1.1.0-cibuild of the CodeX Radiation Therapy FHIR Implementation Guide contains unballoted changes to the published STU1 version.  A detailed list of these changes are available on  the  [Change Log](change_log.html) page.
+</div><!-- stu-note -->
+
 ### Background
 Radiation therapy treatment details – critical for care coordination – are not readily available in information systems beyond radiation oncology information technology (IT) modules. Furthermore, creation of radiation therapy (RT) treatment summary documents is often a manual process, creating clinician burden and potential patient safety issues. Historical RT summary documents tend to be comprised of unstructured data; therefore, providers have been unable to leverage this information to meet reporting requirements (e.g., quality reporting, registry reporting) or support comparative effectiveness research without additional manual data entry.
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -6,10 +6,10 @@ id: hl7.fhir.us.codex-radiation-therapy
 canonical: http://hl7.org/fhir/us/codex-radiation-therapy
 name: CodeX-Radiation-Therapy
 status: draft
-version: 1.0.0
+version: 1.1.0
 fhirVersion: 4.0.1
 copyrightYear: 2021+
-releaseLabel: STU 1
+releaseLabel: STU 1.1
 title: "CodeX Radiation Therapy"
 publisher:
   name: HL7 Cross Group Projects Work Group

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -6,7 +6,7 @@ id: hl7.fhir.us.codex-radiation-therapy
 canonical: http://hl7.org/fhir/us/codex-radiation-therapy
 name: CodeX-Radiation-Therapy
 status: draft
-version: 1.1.0
+version: 1.1.0-cibuild
 fhirVersion: 4.0.1
 copyrightYear: 2021+
 releaseLabel: STU 1.1


### PR DESCRIPTION
category = SCT#108290001 "Radiation oncology AND/OR radiotherapy"
is no more inherited from mCODE Course Summary from mCODE 3.0.0. 
Therefore CodeX RT defines it also on the Course Summary the same way as on other ServiceRequests and Procedures.