### PR TITLE
Fixed typo in urls (radiotheraphy).

### DIFF
--- a/input/fsh/SD_Extensions.fsh
+++ b/input/fsh/SD_Extensions.fsh
@@ -264,7 +264,7 @@ Since point doses mostly have a technical role, high-level summaries may decide 
 * insert UsualContexts
 
 Extension: RadiotherapyReasonForRevisionOrAdaptation
-Id: codexrt-radiotheraphy-reason-for-revision-or-adaptation
+Id: codexrt-radiotherapy-reason-for-revision-or-adaptation
 Title: "Reason for Revision or Adaptation"
 Description: "The reason a planned or prescribed radiotherapy treatment was revised, superceded, or adapted."
 * . ^short = "Reason for Revision or Adaptation"

--- a/input/fsh/SD_RadiotherapyAdverseEvent.fsh
+++ b/input/fsh/SD_RadiotherapyAdverseEvent.fsh
@@ -33,7 +33,7 @@ RuleSet: AdverseEventExtensionPreamble
 
 
 Extension: AdverseEventSeverityOrGrade
-Id: codexrt-radiotheraphy-adverse-event-severity-or-grade
+Id: codexrt-radiotherapy-adverse-event-severity-or-grade
 Title: "Radiotherapy Adverse Event Grade"
 Description: "The grade associated with the severity of an adverse event, using CTCAE criteria. The code '0' representing no adverse event may be used to provide positive confirmation that the clinician assessed or considered this particular AE, although the absence of an adverse event is generally not reportable. See https://ctep.cancer.gov/protocolDevelopment/electronic_applications/ctc.htm"
 * insert AdverseEventExtensionPreamble

--- a/input/fsh/VS_RadiotherapyAdverseEventVS.fsh
+++ b/input/fsh/VS_RadiotherapyAdverseEventVS.fsh
@@ -1,5 +1,5 @@
 CodeSystem: AdverseEventSeverityOrGradeCS
-Id: codexrt-radiotheraphy-adverse-event-severity-or-gradeCS
+Id: codexrt-radiotherapy-adverse-event-severity-or-gradeCS
 Title: "Severity or Grade CodeSystem based on CTCAE"
 Description: "Common terminology criteria (CTC) grades associated with the severity of an adverse event, expressed as integers, 0 through 5, with 0 representing no adverse event, and 5 representing death."
 * ^caseSensitive = true
@@ -12,7 +12,7 @@ Description: "Common terminology criteria (CTC) grades associated with the sever
 * #5 "Death Related to Adverse Event"  "The termination of life associated with an adverse event."
 
 ValueSet: AdverseEventSeverityOrGradeVS
-Id: codexrt-radiotheraphy-adverse-event-severity-or-gradeVS
+Id: codexrt-radiotherapy-adverse-event-severity-or-gradeVS
 Title: "Adverse Event Severity or Grade Value Set"
 Description: "CTCAE Grades 0 through 5. The grade of the adverse event, determined by CTCAE criteria, where 0 represents confirmation that the given adverse event did NOT occur, and 5 represents death. Note that grade 0 events are generally not reportable, but may be created to give positive confirmation that the clinician assessed or considered a particular AE."
 * ^experimental = false

--- a/input/pagecontent/AdverseEvent-RadiotherapyAdverseEvent-XRTS-07-22B-notes.md
+++ b/input/pagecontent/AdverseEvent-RadiotherapyAdverseEvent-XRTS-07-22B-notes.md
@@ -5,7 +5,7 @@ Title: "Example Adverse Event from Radiotherapy"
 Description: "Adverse Event, Nausea following course of treatment."
 Usage: #example
 * extension
-  * url = "http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotheraphy-adverse-event-severity-or-grade"
+  * url = "http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-adverse-event-severity-or-grade"
   * valueCodeableConcept = AdverseEventSeverityOrGradeCS#1 "Mild Adverse Event"
 * actuality = #actual
 * event = http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C146764 "Nausea"

--- a/input/pagecontent/ServiceRequest-RadiotherapyPlannedPhase-XRTS-02-22B-01-01-Primary-notes.md
+++ b/input/pagecontent/ServiceRequest-RadiotherapyPlannedPhase-XRTS-02-22B-01-01-Primary-notes.md
@@ -33,7 +33,7 @@ Usage: #example
     * valueQuantity = 1260 'cGy'
   * url = "http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-dose-planned-to-volume"
 * extension[+]
-  * url = "http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotheraphy-reason-for-revision-or-adaptation"
+  * url = "http://hl7.org/fhir/us/codex-radiation-therapy/StructureDefinition/codexrt-radiotherapy-reason-for-revision-or-adaptation"
   * valueCodeableConcept = http://snomed.info/sct#373858009 "Radiotherapy course change due to acute radiotherapy toxicity (finding)"
 * identifier[0]
   * use = #usual

--- a/input/pagecontent/change_log.md
+++ b/input/pagecontent/change_log.md
@@ -9,6 +9,7 @@ These are the unballoted changes that were made after STU 1 publication.
 
 #### Profile Changes
 * Added required code for Procedure.category in [RadiotherapyCourseSummary](StructureDefinition-codexrt-radiotherapy-course-summary.html). The category was inherited from mCODE [RadiotherapyCourseSummary](https://hl7.org/fhir/us/mcode/STU2.1/StructureDefinition-mcode-radiotherapy-course-summary.html) up to mCODE 2.1.0, but removed in mCODE 3.0.0. Now CodeX RT defines the category for Radiotherapy Course Summary instead of inheriting from mCODE ([FHIR-41764](https://jira.hl7.org/browse/FHIR-41764)).
+* Fixed typo (radiotheraphy) in extension url for [Reason for Revision or Adaptation](StructureDefinition-codexrt-radiotherapy-reason-for-revision-or-adaptation.html) ([FHIR-42893](https://jira.hl7.org/browse/FHIR-42893)). Fixed the same typo in [Radiotherapy Adverse Event Grade](StructureDefinition-codexrt-radiotherapy-adverse-event-severity-or-grade.html), [Severity or Grade CodeSystem based on CTCAE](CodeSystem-codexrt-radiotherapy-adverse-event-severity-or-gradeCS.html), and [Adverse Event Severity or Grade Value Set](ValueSet-codexrt-radiotherapy-adverse-event-severity-or-gradeVS.html).
 
 ### CodeX Radiation Therapy STU1 Publication Version
 These are the changes that were made during ballot reconciliation.


### PR DESCRIPTION
* Fixed typo (radiotheraphy) in extension url for Reason for Revision or Adaptation (https://jira.hl7.org/browse/FHIR-42893). Fixed the same typo in Radiotherapy Adverse Event Grade, Severity or Grade CodeSystem based on CTCAE, and Adverse Event Severity or Grade Value Set.