### PR TITLE
Fix FSNs of isotopes

### DIFF
--- a/input/fsh/VS_RadiotherapyIsotopes.fsh
+++ b/input/fsh/VS_RadiotherapyIsotopes.fsh
@@ -10,7 +10,7 @@ Description: "Isotope used in radiotherapy"
 // cobalt
 * SCT#5405008 "Cobalt-60 (substance)"
 // gold isotopes
-* SCT#24301009  "Gold-198 (substance"
+* SCT#24301009  "Gold-198 (substance)"
 // include all iodine isotopes
 * SCT#68630002 "Iodine-125 (substance)"
 * SCT#1368003 "Iodine-131 (substance)"
@@ -29,7 +29,7 @@ Description: "Isotope used in radiotherapy"
 // include all ruthenium isotopes
 * SCT#8227001 "Ruthenium-106 (substance)"
 // strontium
-* SCT#14071002   "Strontium-90 (substance"
+* SCT#14071002   "Strontium-90 (substance)"
 // xenon
 * SCT#80751004  "Xenon-133 (substance)"
 // yttrium

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -181,9 +181,6 @@ INFORMATION: Condition/Diagnosis-2-Prostate: Condition.category[0]: Reference to
 # Retired extension -- yes included in the base mCODE profile for backward compatibility 
 INFORMATION: StructureDefinition/codexrt-radiotherapy-course-summary: Procedure.extension: The extension http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-treatment-termination-reason|4.0.0-ballot is retired
 
-# This is an issue with SNOMEDCT that is beyond the power of the IG to address
-INFORMATION: ValueSet/codexrt-radiotherapy-isotope-vs: ValueSet.compose.include[0]: This SNOMED-CT based include has some concepts with semantic tags (FSN terms) and some without (preferred terms) - check that this is what is intended  (examples for FSN: [Cesium-131 (substance), Cesium-137 (substance), Cobalt-60 (substance), Iodine-125 (substance), Iodine-131 (substance)] and examples for no FSN: [Gold-198 (substance, Strontium-90 (substance])
-
 # Temporary Codesystem for codes requested from SNOMEDCT.  No point in going through THO Process
 INFORMATION: CodeSystem/snomed-requested-cs: CodeSystem: Most code systems defined in HL7 IGs will need to move to THO later during the process. Consider giving this code system a THO URL now (See https://confluence.hl7.org/display/TSMG/Terminology+Play+Book, and/or talk to TSMG)
 


### PR DESCRIPTION
QA showed an information about FSNs of SNOMED codes. We ignored that earlier, but in fact we can fix it by adding two missing closing brackets.